### PR TITLE
Exclude Normal vim.mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
       {
         "command": "endwise.enter",
         "key": "enter",
-        "when": "editorTextFocus && editorLangId == 'ruby' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' "
+        "when": "editorTextFocus && editorLangId == 'ruby' && vim.mode != 'Normal' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' "
       },
       {
         "command": "endwise.cmdEnter",
         "key": "ctrl+enter",
         "mac": "cmd+enter",
-        "when": "editorTextFocus && editorLangId == 'ruby' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress^' "
+        "when": "editorTextFocus && editorLangId == 'ruby' && vim.mode != 'Normal' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress^' "
       },
       {
         "command": "endwise.checkForAcceptSelectedSuggestion",


### PR DESCRIPTION
Keeps the correct behaviour of the enter key, when in Normal mode