### PR TITLE
Specify extension kind for better performance with remote workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
   "activationEvents": [
     "onLanguage:ruby"
   ],
+  "extensionKind": [
+    "ui",
+    "workspace"
+  ],
   "main": "./out/src/extension",
   "contributes": {
     "keybindings": [


### PR DESCRIPTION
Defining this will make sure the extension prefers running in local UI context when interacting with a remote workspace, which greatly reduces latency.

See details here: https://code.visualstudio.com/api/advanced-topics/remote-extensions#architecture-and-extension-kinds