### PR TITLE
Fix issue with GitHub Copilot by executing the "editor.action.inlineSuggest.trigger" command after modifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ui",
     "workspace"
   ],
-  "main": "./out/src/extension",
+  "main": "./out/extension",
   "contributes": {
     "keybindings": [
       {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -114,6 +114,8 @@ async function endwiseEnter(calledWithModifier = false) {
   } else {
     await linebreak();
   }
+  // Trigger inline suggestion after any modifications (e.g. GitHub Copilot)
+  vscode.commands.executeCommand("editor.action.inlineSuggest.trigger");
 
   /**
    * Insert a line break, add the correct closing and correct cursor position
@@ -127,7 +129,7 @@ async function endwiseEnter(calledWithModifier = false) {
     });
 
     await vscode.commands.executeCommand("cursorUp");
-    vscode.commands.executeCommand("editor.action.insertLineAfter");
+    await vscode.commands.executeCommand("editor.action.insertLineAfter");
   }
 
   /**


### PR DESCRIPTION
I figured it out! Fixes #37

`editor.action.inlineSuggest.trigger` is a built-in VS Code command, so it does nothing if Copilot is disabled or not installed. This will also work with any other extensions that provide autocomplete suggestions.

### Works with Copilot enabled

https://user-images.githubusercontent.com/139536/192654018-5adc724a-c85c-4853-9b4b-c5f9435fa31d.mov

### Also works if Copilot is disabled or not installed

https://user-images.githubusercontent.com/139536/192654046-2da4a596-7371-4570-8006-044fd129def5.mov

