### PR TITLE
Don't add end for endless methods

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,6 +84,7 @@ const OPENINGS_CRYSTAL = [
 ];
 
 const SINGLE_LINE_DEFINITION = /;\s*end[\s;]*$/;
+const ENDLESS_DEFINITION = /^\s*?def\s+[^\s(]+\s*(?:\(.*\))?\s+=/;
 const LINE_PARSE_LIMIT = 100000;
 
 async function endwiseEnter(calledWithModifier = false) {
@@ -168,6 +169,8 @@ async function endwiseEnter(calledWithModifier = false) {
     if (!calledWithModifier && lineText.length > columnNumber) return false;
     // Also, do not close on single line definitions
     if (lineText.match(SINGLE_LINE_DEFINITION)) return false;
+    // Also, do not close on endless definitions
+    if (lineText.match(ENDLESS_DEFINITION)) return false;
 
     for (let condition of openings) {
       if (!lineText.match(condition)) continue;


### PR DESCRIPTION
Resolves https://github.com/kaiwood/vscode-endwise/issues/36

Looks like [this other PR](https://github.com/kaiwood/vscode-endwise/pull/32) might offer a longer-term solution for this issue, but this PR just adds another regex check.

https://user-images.githubusercontent.com/9577458/235750935-4ee200e8-4413-409e-a3df-0f2599fc15f7.mp4