### PR TITLE
Fix main path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ui",
     "workspace"
   ],
-  "main": "./out/src/extension",
+  "main": "./out/extension",
   "contributes": {
     "keybindings": [
       {


### PR DESCRIPTION
When `src/extension.ts` is compiled the resulting file is created directly in the `out/` directory, not `out/src/`.

When I tried to use the extension directly from the marketplace I got the following error in the developer console, and it completely broke the `Enter` key:

    workbench.desktop.main.js:1978 Activating extension 'kaiwood.endwise' failed: Cannot find module '~/.vscode-oss/extensions/kaiwood.endwise-1.5.1-universal/out/src/extension'
    Require stack:
    - /usr/share/codium/resources/app/out/vs/loader.js
    - /usr/share/codium/resources/app/out/bootstrap-amd.js
    - /usr/share/codium/resources/app/out/bootstrap-fork.js
    - .

Running from a pristine git clone resulted in a similar error, but after making this change the extension works correctly.

This may be due to me using the codium here rather than the "official" VSCode. On another computer where I do use the official release, the version from the marketplace works, but running from a git clone seems to require this change as well.